### PR TITLE
feat: Enhance session management with remember preference for persist…

### DIFF
--- a/src/services/api-auth.js
+++ b/src/services/api-auth.js
@@ -55,6 +55,7 @@ export const loginUser = async (userData) => {
       userId: result.userId,
       userEmail: userData.email,
       sessionId: `user_${result.userId}`,
+      remember: userData.remember || false,
     });
 
     try {

--- a/src/state/data-persistence.js
+++ b/src/state/data-persistence.js
@@ -134,14 +134,12 @@ export const TrashPersistence = {
  */
 export const SessionPersistence = {
   /**
-   * Loads session data using StorageManager
+   * Loads session data using StorageManager (checks both storage types)
    * @returns {Object|null} Session object or null
    */
   load() {
     try {
-      const session = StorageManager.getSessionData(
-        StorageKeys.SESSION.AUTH_DATA
-      );
+      const session = StorageManager.getAuthData(StorageKeys.SESSION.AUTH_DATA);
       return session;
     } catch (error) {
       console.error("Error loading session:", error);
@@ -150,23 +148,34 @@ export const SessionPersistence = {
   },
 
   /**
-   * Saves session data using StorageManager
+   * Saves session data using StorageManager with remember preference
    * @param {Object} sessionData - Session data to save
+   * @param {boolean} [remember=false] - Whether to use persistent storage
    */
-  save(sessionData) {
+  save(sessionData, remember = false) {
     try {
-      StorageManager.setSessionData(StorageKeys.SESSION.AUTH_DATA, sessionData);
+      if (remember) {
+        StorageManager.removeData("session", StorageKeys.SESSION.AUTH_DATA);
+      } else {
+        StorageManager.removeData("local", StorageKeys.SESSION.AUTH_DATA);
+      }
+
+      StorageManager.setAuthData(
+        remember,
+        StorageKeys.SESSION.AUTH_DATA,
+        sessionData
+      );
     } catch (error) {
       console.error("Error saving session:", error);
     }
   },
 
   /**
-   * Removes session data from storage
+   * Removes session data from both storage types
    */
   clear() {
     try {
-      StorageManager.removeData("session", StorageKeys.SESSION.AUTH_DATA);
+      StorageManager.removeAuthData(StorageKeys.SESSION.AUTH_DATA);
     } catch (error) {
       console.error("Error clearing session:", error);
     }

--- a/src/state/session-manager.js
+++ b/src/state/session-manager.js
@@ -55,11 +55,19 @@ export const SessionManager = {
    * Saves current session data to storage
    * @param {Object} appState - Application state object
    * @param {Function} getCurrentView - Function to get current view
+   * @param {boolean} [remember] - Whether to use persistent storage (auto-detect if not provided)
    */
-  saveToStorage(appState, getCurrentView) {
+  saveToStorage(appState, getCurrentView, remember) {
     try {
       if (!appState.sessionType) {
         return;
+      }
+
+      // Auto-detect remember preference from existing session if not provided
+      if (remember === undefined) {
+        const existingSession = SessionPersistence.load();
+        remember = existingSession?.remember || false;
+        console.log(`🔍 Auto-detected remember preference: ${remember}`);
       }
 
       const sessionData = {
@@ -69,8 +77,9 @@ export const SessionManager = {
         userEmail: appState.userEmail,
         lastView: getCurrentView(),
         timestamp: Date.now(),
+        remember: remember,
       };
-      SessionPersistence.save(sessionData);
+      SessionPersistence.save(sessionData, remember);
     } catch (error) {
       console.error("Error saving session:", error);
     }
@@ -98,7 +107,8 @@ export const SessionManager = {
       this.reloadSessionData(appState);
     }
 
-    this.saveToStorage(appState, getCurrentView);
+    const remember = sessionData.remember || false;
+    this.saveToStorage(appState, getCurrentView, remember);
     notifyListeners();
   },
 

--- a/src/state/storage.js
+++ b/src/state/storage.js
@@ -138,6 +138,54 @@ export const StorageManager = {
   // === UTILITY FUNCTIONS ===
 
   /**
+   * Save data to storage type dynamically based on remember preference
+   * @param {boolean} remember - Whether to use persistent storage
+   * @param {string} key - Storage key
+   * @param {any} data - Data to store
+   */
+  setAuthData(remember, key, data) {
+    const storageType = remember ? StorageTypes.LOCAL : StorageTypes.SESSION;
+    console.log(`💾 Saving auth data to ${storageType} storage (remember: ${remember})`);
+
+    if (remember) {
+      this.setLocalData(key, data);
+    } else {
+      this.setSessionData(key, data);
+    }
+  },
+
+  /**
+   * Load auth data from either storage type
+   * @param {string} key - Storage key
+   * @returns {any|null} Auth data or null
+   */
+  getAuthData(key) {
+    const localData = this.getLocalData(key);
+    if (localData) {
+      console.log(`🔓 Auth data loaded from localStorage (persistent)`);
+      return localData;
+    }
+
+    const sessionData = this.getSessionData(key);
+    if (sessionData) {
+      console.log(`🔓 Auth data loaded from sessionStorage (temporary)`);
+      return sessionData;
+    }
+
+    return null;
+  },
+
+  /**
+   * Remove auth data from both storage types
+   * @param {string} key - Storage key
+   */
+  removeAuthData(key) {
+    this.removeData(StorageTypes.LOCAL, key);
+    this.removeData(StorageTypes.SESSION, key);
+    console.log(`🗑️ Auth data removed from both storage types`);
+  },
+
+  /**
    * Remove data from specific storage type
    * @param {string} type - Storage type (session|local|memory)
    * @param {string} key - Storage key


### PR DESCRIPTION
This pull request introduces improvements to session persistence and authentication state management, focusing on supporting a "remember me" feature for users. The changes ensure that authentication and session data are stored either in persistent (localStorage) or temporary (sessionStorage) storage based on the user's preference, and streamline how session data is saved, loaded, and cleared across the app.

**Session persistence and "remember me" support:**
* Added a `remember` flag to session data during user login to indicate whether the session should be persisted or temporary.
* Updated `SessionPersistence` methods to save, load, and clear session data from both storage types, and to use the `remember` flag to determine where to store the data.

**Storage utility enhancements:**
* Added new methods to `StorageManager` for saving, loading, and removing authentication data from both local and session storage, providing a unified interface for handling auth data.