### PR TITLE
feat: Add dark mode styles for trash todo items, enhancing visibility…

### DIFF
--- a/src/styles/data-theme.css
+++ b/src/styles/data-theme.css
@@ -432,3 +432,55 @@ body[data-theme="dark"] {
 [data-theme="dark"] .invalid-token-message p {
   color: var(--text-secondary) !important;
 }
+
+/* ===========================================
+   TRASH TODO ITEMS - DARK MODE
+   =========================================== */
+
+/* Main trash todo item container */
+[data-theme="dark"] .trash-todo-item {
+  background: rgba(45, 45, 45, 0.95) !important;
+  border-left: 4px solid #ff6b6b !important;
+  border-top: 1px solid #555555;
+  border-right: 1px solid #555555;
+  border-bottom: 1px solid #555555;
+}
+
+[data-theme="dark"] .trash-todo-item:hover {
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.4) !important;
+}
+
+/* Trash todo header */
+[data-theme="dark"] .trash-todo-header {
+  border-bottom: 1px solid #555555;
+}
+
+/* Trash todo title */
+[data-theme="dark"] .trash-todo-title {
+  color: var(--text-primary) !important;
+}
+
+/* Trash todo content text */
+[data-theme="dark"] .trash-todo-text {
+  color: var(--text-primary) !important;
+}
+
+/* Trash todo metadata */
+[data-theme="dark"] .trash-todo-meta {
+  color: var(--text-secondary) !important;
+}
+
+[data-theme="dark"] .trash-todo-date {
+  color: #ff6b6b !important;
+}
+
+[data-theme="dark"] .trash-todo-original-date {
+  color: var(--text-secondary) !important;
+}
+
+/* Trash todo placeholder */
+[data-theme="dark"] .trash-todo-placeholder {
+  background: rgba(45, 45, 45, 0.3) !important;
+  border: 1px solid #555555;
+  color: var(--text-primary) !important;
+}

--- a/src/styles/trash.css
+++ b/src/styles/trash.css
@@ -111,6 +111,7 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 0.5rem;
+  padding-bottom: 0.5rem;
 }
 
 .trash-todo-title {


### PR DESCRIPTION
This pull request adds dark mode styling for trash todo items and makes a minor layout adjustment to the trash todo header. The main focus is to ensure that trashed todo items are visually distinct and consistent with the dark theme.

**Dark mode styling for trash todo items:**

* Added comprehensive CSS rules under `[data-theme="dark"]` in `data-theme.css` to style trash todo item containers, headers, titles, content, metadata, and placeholders for dark mode. These changes use appropriate background colors, borders, and text colors to match the dark theme and visually highlight trashed items.

**Layout improvement:**

* Added `padding-bottom` to the `.trash-todo-header` class in `trash.css` to improve spacing and layout consistency.… and aesthetics